### PR TITLE
Fix for WP Stream date formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ $ composer require devgeniem/wp-geniem-project-bells-and-whistles
 
 Disables the periodical admin email verification that was introduced in WordPress version 5.3.
 
+#### FixStreamDateFormat
+
+Fixes the date format in the WP Stream plugin database queries to make it work with Geniem's databases.
+
 ### Disabling a feature class
 
 To disable a feature defined in a specific class, add its class name without the namespace into the following constant in your WordPress configuration file (e.g. wp-config.php):

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "devgeniem/wp-geniem-project-bells-and-whistles",
     "type": "wordpress-muplugin",
-    "license": "GPL3",
+    "license": "GPL-3.0-or-later",
     "description": "Geniem WP Project Bells & Whistles",
     "homepage": "http://geniem.com",
     "authors": [

--- a/plugin.php
+++ b/plugin.php
@@ -23,6 +23,7 @@ if ( file_exists(__DIR__ . '/vendor/autoload.php' ) ) {
 $classes = [
     Project\DisableAdminEmailVerification::class,
     Project\Add404Headers::class,
+    Project\FixStreamDateFormat::class,
 ];
 
 // Add your development feature classes here.

--- a/src/FixStreamDateFormat.php
+++ b/src/FixStreamDateFormat.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Fix a date format bug in WP Stream database queries.
+ * Original date format in plugin is not supported by our platform.
+ */
+
+namespace Geniem\Project;
+
+/**
+ * FixStreamDateFormat class
+ */
+class FixStreamDateFormat {
+
+    /**
+     * The constructor ads the hook.
+     */
+    public function __construct() {
+        \add_action( 'wp_stream_record_array', [ $this, 'fix_stream_date_format' ], 10, 1 );
+    }
+
+    /**
+     * Convert date field value for Stream plugin.
+     *
+     * @param array $data Data that Stream saves.
+     * @return array
+     */
+    public function fix_stream_date_format( $data ) {
+        $data['created'] = date( 'Y-m-d H:i:s', strtotime( $data['created'] ) );
+        return $data;
+    }
+}


### PR DESCRIPTION
Fixes date formatting used in the WP Stream plugin when adding log records into the database.