### PR TITLE
Gutenberg fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.5.0] - 2021-01-29
+
+### Added
+- Disable Gutenberg default fullscreen mode.
+- Disable Gutenberg core block patterns.
+- Hide Gutenberg device preview options with CSS.
+
 ## [1.4.0] - 2020-02-13
 
 ### Added

--- a/plugin.php
+++ b/plugin.php
@@ -24,6 +24,9 @@ $classes = [
     Project\DisableAdminEmailVerification::class,
     Project\Add404Headers::class,
     Project\FixStreamDateFormat::class,
+    Project\DisableGutenbergAutoFullscreen::class,
+    Project\DisableGutenbergBlockPatterns::class,
+    Project\DisableGutenbergDevicePreviewOptions::class,
 ];
 
 // Add your development feature classes here.

--- a/src/DisableGutenbergAutoFullscreen.php
+++ b/src/DisableGutenbergAutoFullscreen.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Disable Gutenberg automatic full-screen mode
+ */
+
+namespace Geniem\Project;
+
+/**
+ * DisableGutenbergAutoFullscreen class.
+ */
+class DisableGutenbergAutoFullscreen {
+
+    /**
+     * The constructor.
+     */
+    public function __construct() {
+        add_action( 'enqueue_block_editor_assets', [ $this, 'disable_gutenberg_auto_fullscreen' ] );
+    }
+
+    /**
+     * Register inline script disabling auto-fullscreen mode from Gutenberg
+     *
+     * @return void
+     */
+    public function disable_gutenberg_auto_fullscreen() {
+        $script = "
+window.onload = function() {
+    if ( wp.data.select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' ) ) {
+        wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'fullscreenMode' );
+    }
+}";
+
+        wp_add_inline_script( 'wp-blocks', $script );
+    }
+}

--- a/src/DisableGutenbergBlockPatterns.php
+++ b/src/DisableGutenbergBlockPatterns.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Disable Gutenberg block patterns
+ */
+
+namespace Geniem\Project;
+
+/**
+ * DisableGutenbergBlockPatterns class.
+ */
+class DisableGutenbergBlockPatterns {
+
+    /**
+     * The constructor.
+     */
+    public function __construct() {
+        add_action( 'after_setup_theme', [ $this, 'disable_gutenberg_block_patterns' ] );
+    }
+
+    /**
+     * Remove theme support for core-block-patterns
+     *
+     * @return void
+     */
+    public function disable_gutenberg_block_patterns() {
+        remove_theme_support( 'core-block-patterns' );
+    }
+}

--- a/src/DisableGutenbergDevicePreviewOptions.php
+++ b/src/DisableGutenbergDevicePreviewOptions.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Disable Gutenberg device preview options (Mobile, Tablet)
+ */
+
+namespace Geniem\Project;
+
+/**
+ * DisableGutenbergDevicePreviewOptions class.
+ */
+class DisableGutenbergDevicePreviewOptions {
+
+    /**
+     * The constructor.
+     */
+    public function __construct() {
+        add_action( 'enqueue_block_editor_assets', [ $this, 'disable_gutenberg_device_preview_options' ] );
+    }
+
+    /**
+     * Register inline styles hiding the options from Gutenberg device preview dropdown
+     *
+     * @return void
+     */
+    public function disable_gutenberg_device_preview_options() {
+        $style = "
+.edit-post-post-preview-dropdown .components-dropdown-menu__menu .components-menu-group + .components-menu-group {
+    border-top: none;
+}
+
+.block-editor-post-preview__button-resize {
+    display: none;
+}";
+
+        wp_add_inline_style( 'wp-block-library', $style );
+    }
+}


### PR DESCRIPTION
* Disable Gutenberg default fullscreen mode.
* Disable Gutenberg core block patterns.
* Hide Gutenberg device preview options with CSS.