### PR TITLE
Treat FLoC as a security concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Disable Google's FloC Tracking with the class `DisableFloc`.
+
 ## [1.6.0] - 2021-04-09
 - Disable big image size treshold with the class `DisableBigImageSizeTreshold`.
 

--- a/plugin.php
+++ b/plugin.php
@@ -25,6 +25,7 @@ $classes = [
     Project\Add404Headers::class,
     Project\FixStreamDateFormat::class,
     Project\DisableBigImageSizeTreshold::class,
+    Project\DisableFloc::class,
     Project\DisableGutenbergAutoFullscreen::class,
     Project\DisableGutenbergBlockPatterns::class,
     Project\DisableGutenbergDevicePreviewOptions::class,

--- a/src/DisableFloc.php
+++ b/src/DisableFloc.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Treat FLoC as a security concern.
+ *
+ * TL;DR: FLoC places people in groups based on their browsing habits to target advertising.
+ *
+ * Why is this bad?
+ * As the Electronic Frontier Foundation explains in their post
+ * “Google’s FLoC is a terrible idea“[1], placing people in groups based on their browsing
+ * habits is likely to facilitate employment, housing and other types of discrimination,
+ * as well as predatory targeting of unsophisticated consumers.
+ *
+ * This is in addition to the privacy concerns of tracking people and sharing their data,
+ * seemingly without informed consent – and making it more difficult for legislators and
+ * regulators to protect people.
+ *
+ * [1]: https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea
+ * Source: https://make.wordpress.org/core/2021/04/18/proposal-treat-floc-as-a-security-concern/
+ */
+
+namespace Geniem\Project;
+
+/**
+ * DisableFloc class.
+ */
+class DisableFloc {
+
+    /**
+     * The constructor.
+     */
+    public function __construct() {
+        add_action( 'init', [ $this, 'run_on_init' ] );
+    }
+
+    /**
+     * Add wp_headers filter.
+     *
+     * @return void
+     */
+    public function run_on_init() {
+        add_filter( 'wp_headers', [ $this, 'disable_floc' ] );
+    }
+
+    /**
+     * Add `interest-cohort=()` as `Permissions-Policy` header.
+     *
+     * @param array $headers WP_Headers array.
+     *
+     * @return array
+     */
+    public function disable_floc( $headers = [] ) {
+        $headers['Permissions-Policy'] = 'interest-cohort=()';
+
+        return $headers;
+    }
+}


### PR DESCRIPTION
> TL;DR: FLoC places people in groups based on their browsing habits to target advertising.
> 
> Why is this bad?
> As the Electronic Frontier Foundation explains in their post [“Google’s FLoC is a terrible idea“][1], placing people in groups based on their browsing habits is likely to facilitate employment, housing and other types of discrimination, as well as predatory targeting of unsophisticated consumers.
> 
> This is in addition to the privacy concerns of tracking people and sharing their data, seemingly without informed consent – and making it more difficult for legislators and regulators to protect people.

Source: https://make.wordpress.org/core/2021/04/18/proposal-treat-floc-as-a-security-concern/

[1]: https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea